### PR TITLE
Fixed crash on start up 

### DIFF
--- a/src/com/lekebilen/quasseldroid/CoreConnection.java
+++ b/src/com/lekebilen/quasseldroid/CoreConnection.java
@@ -83,8 +83,13 @@ public class CoreConnection {
 				return true;
 			} catch (Exception e) {
 				Message msg = service.getHandler().obtainMessage(R.id.CORECONNECTION_DISCONNECTED);
-				msg.obj = buffers.values();
-				msg.sendToTarget();
+				
+				// Do not crash on start up if we don't have buffer (will output invalid username/password combination)
+				if(buffers != null) {
+					msg.obj = buffers.values();
+					msg.sendToTarget();
+				}
+				
 				return false;
 			}
 		}


### PR DESCRIPTION
QuasselDroid crashed in a situation where username/password was invalid and buffer was not for some reason available when exception handling begun.
