### PR TITLE
Show (off)/(away) after queryname if user is offline/away

### DIFF
--- a/src/com/iskrembilen/quasseldroid/gui/BufferActivity.java
+++ b/src/com/iskrembilen/quasseldroid/gui/BufferActivity.java
@@ -67,6 +67,8 @@ import com.iskrembilen.quasseldroid.Network;
 import com.iskrembilen.quasseldroid.NetworkCollection;
 import com.iskrembilen.quasseldroid.service.CoreConnService;
 import com.iskrembilen.quasseldroid.R;
+import com.iskrembilen.quasseldroid.IrcUser;
+
 
 public class BufferActivity extends ExpandableListActivity {
 
@@ -314,6 +316,25 @@ public class BufferActivity extends ExpandableListActivity {
 				//				if (boundConnService.hasUser(nick)){
 				//					nick += boundConnService.getUser(nick).away ? " (Away)": "";
 				//				}
+
+				List<IrcUser> nickList = this.networks.getNetwork(groupPosition).getUserList();
+				
+				int nick_found = 0;                     
+				         
+				for (IrcUser ircuser : nickList) {
+					if (ircuser.name.startsWith(nick)) {
+						nick_found  = 1;
+					    if (ircuser.away) {
+					    	nick += " (away)";
+					    }
+					    break;
+					}
+				
+				}
+				if (nick_found == 0){
+					nick += " (off)";
+				}
+
 				holder.bufferView.setText(nick);
 				break;
 			case GroupBuffer:


### PR DESCRIPTION
Hi

I allready patched this in an older version of quasseldroid but after updating the git repo it got broken again. so i readded this feature.

maybee you would like to add it to master.

with regards
christian
