### PR TITLE
remove theme attribute from PreferenceView activity

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -24,8 +24,7 @@
         <activity
             android:name=".gui.PreferenceView"
             android:label="@string/app_name"
-            android:screenOrientation="sensor"
-            android:theme="@android:style/Theme" >
+            android:screenOrientation="sensor" >
         </activity>
         <activity
             android:name=".gui.ChatActivity"


### PR DESCRIPTION
Removing the attribute makes the PreferenceView use the application theme
