### PR TITLE
Classpath file has environment/developer-specific paths

### DIFF
--- a/.classpath.dist
+++ b/.classpath.dist
@@ -5,11 +5,8 @@
 	<classpathentry kind="src" path="gen"/>
 	<classpathentry kind="con" path="com.android.ide.eclipse.adt.LIBRARIES"/>
 	<classpathentry kind="lib" path="libs/crittercism_v2_1_3_rev1.jar"/>
-	<classpathentry kind="lib" path="libs/android-support-v4.jar" sourcepath="C:/Program Files (x86)/Android/android-sdk/extras/android/support/v4/src/">
-		<attributes>
-			<attribute name="javadoc_location" value="file:/C:/Program Files (x86)/Android/android-sdk/extras/android/support/v4/docs/"/>
-		</attributes>
-	</classpathentry>
+	<classpathentry kind="lib" path="libs/android-support-v4.jar"/>
 	<classpathentry kind="lib" path="libs/square-otto-1.2.1.jar"/>
+	<classpathentry kind="src" path="/actionbarsherlock"/>
 	<classpathentry kind="output" path="bin/classes"/>
 </classpath>

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 bin/*
 gen/*
+/.classpath


### PR DESCRIPTION
The `.classpath` file contains absolute paths to `C:/Program Files (x86)/Android/android-sdk` which is not where everyone (e.g. me) has the Android SDK installed. It also has no reference at all to `actionbarsherlock`.

Since both of these issues make the project even harder to persuade to build from a fresh clone/fork than it already is, I've tidied up the `.classpath` file and moved it all to a `.classpath.dist` file (with `.classpath` now in `.gitignore`). Everyone who checks out the repository can now simply copy `.classpath.dist` into `.classpath` and make any changes they need to in there without worrying about accidentally committing changes that are specific to their own environment.

This is also the foundation that allows for future pull requests to be made easily without having to mess around with the `.classpath` file to exclude it from the request.

Commit message follows:

---

Removed developer-specific paths from the .classpath file and renamed it as .classpath.dist, adding .classpath to the ignore list so that the project can be built successfully regardless of platform and environment, and changing the .classpath to suit the developer's own environment won't cause problems for other developers if the .classpath is accidentally committed (just remember to make any actually-global .classpath changes in the .classpath.dist file as well!). This issue was also making it even more difficult to issue pull requests from forks.
