### PR TITLE
Another minor issue with mIRC formatting/colours

### DIFF
--- a/src/com/iskrembilen/quasseldroid/util/MessageUtil.java
+++ b/src/com/iskrembilen/quasseldroid/util/MessageUtil.java
@@ -68,33 +68,12 @@ public class MessageUtil {
 		int start, end, endSearchOffset, startIndicatorLength, style, fg, bg;
 		while (true) {
 			content = newString.toString();
+			start = -1;
 			end = -1;
 			startIndicatorLength = 1;
 			style = 0;
 			fg = -1;
 			bg = -1;
-
-			start = content.indexOf(boldIndicator);
-			if (start != -1) {
-				end = content.indexOf(boldIndicator, start+1);
-				style = Typeface.BOLD;
-			}
-
-			if (start == -1) {
-				start = content.indexOf(italicIndicator);
-				if (start != -1) {
-					end = content.indexOf(italicIndicator, start+1);
-					style = Typeface.ITALIC;
-				}
-			}
-
-			if (start == -1) {
-				start = content.indexOf(underlineIndicator);
-				if (start != -1) {
-					end = content.indexOf(underlineIndicator, start+1);
-					style = -1;
-				}
-			}
 
 			endSearchOffset = start + 1;
 
@@ -132,6 +111,30 @@ public class MessageUtil {
 					startIndicatorLength = endSearchOffset - start;
 
 					end = content.indexOf(colorIndicator, endSearchOffset);
+				}
+			}
+
+			if (start == -1) {
+				start = content.indexOf(boldIndicator);
+				if (start != -1) {
+					end = content.indexOf(boldIndicator, start+1);
+					style = Typeface.BOLD;
+				}
+			}
+
+			if (start == -1) {
+				start = content.indexOf(italicIndicator);
+				if (start != -1) {
+					end = content.indexOf(italicIndicator, start+1);
+					style = Typeface.ITALIC;
+				}
+			}
+
+			if (start == -1) {
+				start = content.indexOf(underlineIndicator);
+				if (start != -1) {
+					end = content.indexOf(underlineIndicator, start+1);
+					style = -1;
 				}
 			}
 


### PR DESCRIPTION
Swapped the ordering of searching for bold/underline/invert vs. colours so that ^B^B (or similar) can be used to separate a colour code from a number that should be coloured (for those of us - like me until five minutes ago - who hadn't thought of zero-padding single-digit colour codes). This brings QuasselDroid's behaviour in line with the official Quassel client.

The original issue description from my fork:

---

![examples](http://i.imgur.com/UhbK867.png)

`[^C{WHITE_BOLD}^B^B3k▷^R, ^C{GREEN}^B^B187☺^R/^C{RED}^B^B3☹^R, ^C{WHITE}^B^B44✍^R]`
`[^C0^B^B3k▷^R, ^C3^B^B187☺^R/^C5^B^B3☹^R, ^C15^B^B44✍^R]`

`[^C{WHITE_BOLD}^B^B2M▷^R, ^C{GREEN}^B^B27k☺^R/^C{RED}^B^B786☹^R, ^C{WHITE}^B^B8k✍^R]`
`[^C0^B^B2M▷^R, ^C3^B^B27k☺^R/^C5^B^B786☹^R, ^C15^B^B8k✍^R]`
