### PR TITLE
do not serialize stuff twice

### DIFF
--- a/QuasselDroid/src/main/java/com/iskrembilen/quasseldroid/io/CoreConnection.java
+++ b/QuasselDroid/src/main/java/com/iskrembilen/quasseldroid/io/CoreConnection.java
@@ -622,7 +622,7 @@ public final class CoreConnection {
 				//QMetaTypeRegistry.instance().getTypeForId(QMetaType.Type.QVariant.getValue()).getSerializer().unserialize(bis, DataStreamVersion.Qt_4_2);
 	
 				// Send data 
-				QMetaTypeRegistry.serialize(QMetaType.Type.QVariant, outStream, data);
+				outStream.write(baos.toByteArray());
 				bos.close();
 				baos.close();
 			} catch (IOException e) {


### PR DESCRIPTION
Little change to reuse the already serialized data (which is used to calculate the size) instead of serializing it again
