### PR TITLE
Fix crashes occurring after deleting a buffer.

### DIFF
--- a/QuasselDroid/src/main/java/com/iskrembilen/quasseldroid/events/BufferOpenedEvent.java
+++ b/QuasselDroid/src/main/java/com/iskrembilen/quasseldroid/events/BufferOpenedEvent.java
@@ -3,9 +3,15 @@ package com.iskrembilen.quasseldroid.events;
 public class BufferOpenedEvent {
 	
 	public final int bufferId;
+	public final boolean switchToBuffer;
 	
-	public BufferOpenedEvent(int bufferId) {
+	public BufferOpenedEvent(int bufferId, boolean switchToBuffer) {
 		this.bufferId = bufferId;
+		this.switchToBuffer = switchToBuffer;
+	}
+	
+	public BufferOpenedEvent(int bufferId){
+		this(bufferId,true);
 	}
 
 }

--- a/QuasselDroid/src/main/java/com/iskrembilen/quasseldroid/events/BufferRemovedEvent.java
+++ b/QuasselDroid/src/main/java/com/iskrembilen/quasseldroid/events/BufferRemovedEvent.java
@@ -1,0 +1,11 @@
+package com.iskrembilen.quasseldroid.events;
+
+public class BufferRemovedEvent {
+	
+	public final int bufferId;
+	
+	public BufferRemovedEvent(int bufferId) {
+		this.bufferId = bufferId;
+	}
+
+}

--- a/QuasselDroid/src/main/java/com/iskrembilen/quasseldroid/gui/MainActivity.java
+++ b/QuasselDroid/src/main/java/com/iskrembilen/quasseldroid/gui/MainActivity.java
@@ -380,7 +380,9 @@ public class MainActivity extends SherlockFragmentActivity {
 	public void onBufferOpened(BufferOpenedEvent event) {
 		if(event.bufferId != -1) {
 			openedBuffer = event.bufferId;
-            drawer.closeDrawers();
+			if(event.switchToBuffer){
+				drawer.closeDrawers();
+			}
 		}
 	}
 	
@@ -388,6 +390,15 @@ public class MainActivity extends SherlockFragmentActivity {
 	 public BufferOpenedEvent produceBufferOpenedEvent() {
 		 return new BufferOpenedEvent(openedBuffer);
 	 }
+	 
+	@Subscribe
+	public void onBufferRemoved(BufferRemovedEvent event) {
+		if(event.bufferId == openedBuffer) {
+			openedBuffer = -1;
+			BusProvider.getInstance().post(new BufferOpenedEvent(-1, false));
+			drawer.openDrawer(Gravity.LEFT);
+		}
+	}
 
     private ServiceConnection focusConnection = new ServiceConnection() {
         public void onServiceConnected( ComponentName cn, IBinder service ) {}

--- a/QuasselDroid/src/main/java/com/iskrembilen/quasseldroid/gui/fragments/ChatFragment.java
+++ b/QuasselDroid/src/main/java/com/iskrembilen/quasseldroid/gui/fragments/ChatFragment.java
@@ -612,9 +612,13 @@ public class ChatFragment extends SherlockFragment {
 	@Subscribe
 	public void onBufferOpened(BufferOpenedEvent event) {
         Log.d(TAG, "onBufferOpened event");
+        this.bufferId = event.bufferId;
 		if(event.bufferId != -1) {
-			this.bufferId = event.bufferId;
 			setBuffer(bufferId);
+		}else{
+			adapter.clearBuffer();
+			topicView.setText("");
+			topicViewFull.setText("");
 		}
         Log.d(TAG, "onBufferOpened done");
 	}


### PR DESCRIPTION
The issue was that deleted buffers were still left being displayed in the interface, so any attempt to delete a buffer was causing app crashing.  This switches the displayed buffer to an empty buffer upon deleting a buffer, which prevents the crashes.
