### PR TITLE
Do not assign the network name to network status buffers.

### DIFF
--- a/QuasselDroid/src/main/java/com/iskrembilen/quasseldroid/Network.java
+++ b/QuasselDroid/src/main/java/com/iskrembilen/quasseldroid/Network.java
@@ -60,7 +60,6 @@ public class Network extends Observable implements Observer, Comparable<Network>
 
 	public void setStatusBuffer(Buffer statusBuffer) {
 		this.statusBuffer = statusBuffer;
-		statusBuffer.getInfo().name = networkName;
 		this.setChanged();
 		notifyObservers();
 	}
@@ -81,8 +80,6 @@ public class Network extends Observable implements Observer, Comparable<Network>
 
 	public void setName(String networkName) {
 		this.networkName = networkName;
-		if(statusBuffer != null) //TODO: remember to handle when adding status buffer after connect
-			statusBuffer.getInfo().name = networkName;
 	}
 
 

--- a/QuasselDroid/src/main/java/com/iskrembilen/quasseldroid/gui/MainActivity.java
+++ b/QuasselDroid/src/main/java/com/iskrembilen/quasseldroid/gui/MainActivity.java
@@ -44,6 +44,8 @@ import android.content.res.Configuration;
 import android.content.Context;
 
 import com.actionbarsherlock.app.SherlockFragmentActivity;
+import com.iskrembilen.quasseldroid.Buffer;
+import com.iskrembilen.quasseldroid.BufferInfo;
 import com.iskrembilen.quasseldroid.NetworkCollection;
 import com.iskrembilen.quasseldroid.Quasseldroid;
 import com.iskrembilen.quasseldroid.R;
@@ -135,7 +137,12 @@ public class MainActivity extends SherlockFragmentActivity {
                 if(chatFragment != null) chatFragment.setMenuVisibility(true);
 
                 if(openedBuffer != -1) {
-                    getSupportActionBar().setTitle(NetworkCollection.getInstance().getBufferById(openedBuffer).getInfo().name);
+                    NetworkCollection networks = NetworkCollection.getInstance();
+                    Buffer buffer = networks.getBufferById(openedBuffer);
+                    if (buffer.getInfo().type == BufferInfo.Type.StatusBuffer)
+                        getSupportActionBar().setTitle(networks.getNetworkById(buffer.getInfo().networkId).getName());
+                    else
+                        getSupportActionBar().setTitle(buffer.getInfo().name);
                 } else {
                     getSupportActionBar().setTitle(getResources().getString(R.string.app_name));
                     invalidateOptionsMenu();

--- a/QuasselDroid/src/main/java/com/iskrembilen/quasseldroid/gui/fragments/ChatFragment.java
+++ b/QuasselDroid/src/main/java/com/iskrembilen/quasseldroid/gui/fragments/ChatFragment.java
@@ -324,11 +324,12 @@ public class ChatFragment extends SherlockFragment {
 			if ( buffer.getInfo().type == BufferInfo.Type.QueryBuffer ){
 				topic = buffer.getInfo().name;
 			} else if ( buffer.getInfo().type == BufferInfo.Type.StatusBuffer ){
-				topic = buffer.getInfo().name + " ("
-						+ networks.getNetworkById(buffer.getInfo().networkId).getServer() + ") | "
+				Network network = networks.getNetworkById(buffer.getInfo().networkId);
+				topic = network.getName() + " ("
+						+ network.getServer() + ") | "
 						+ getResources().getString(R.string.users) + ": "
-						+ networks.getNetworkById(buffer.getInfo().networkId).getCountUsers() + " | "
-						+ Helper.formatLatency(networks.getNetworkById(buffer.getInfo().networkId).getLatency(), getResources());
+						+ network.getCountUsers() + " | "
+						+ Helper.formatLatency(network.getLatency(), getResources());
 			} else{
 				 topic = buffer.getInfo().name + ": " + buffer.getTopic();
 			}


### PR DESCRIPTION
This fixes Issue #98 (https://github.com/sandsmark/QuasselDroid/issues/98) which was caused by the fact that the Quassel core decides whether or not to insert a message into a buffer (and therefore create a new buffer if it does not exist) by whether the buffer name is the empty string.  The proper Quassel client always keeps the buffer name for status buffers set to the empty string, so QuasselDroid should too.
