### PR TITLE
Fix text coloring of queries in the buffer list.

### DIFF
--- a/QuasselDroid/src/main/java/com/iskrembilen/quasseldroid/gui/fragments/BufferFragment.java
+++ b/QuasselDroid/src/main/java/com/iskrembilen/quasseldroid/gui/fragments/BufferFragment.java
@@ -132,8 +132,6 @@ public class BufferFragment extends SherlockFragment implements OnGroupExpandLis
 
 	private ActionModeData actionModeData = new ActionModeData();
 
-	private int offlineColor;
-
 	private int openedBufferId = -1;
 
 	public static BufferFragment newInstance() {
@@ -148,7 +146,6 @@ public class BufferFragment extends SherlockFragment implements OnGroupExpandLis
 			restoreItemPosition = savedInstanceState.getInt(ITEM_POSITION_KEY);
 		}
 		setHasOptionsMenu(true);
-		offlineColor = getResources().getColor(R.color.buffer_offline_color);
 		preferences = PreferenceManager.getDefaultSharedPreferences(getSherlockActivity());
 		sharedPreferenceChangeListener =new OnSharedPreferenceChangeListener() {
 
@@ -496,11 +493,16 @@ public class BufferFragment extends SherlockFragment implements OnGroupExpandLis
 				String nick = entry.getInfo().name;
 				if (!bufferListAdapter.networks.getNetworkById(entry.getInfo().networkId).hasNick(nick)) {
 					holder.bufferImage.setImageBitmap(userOfflineBitmap);
-					holder.bufferView.setTextColor(offlineColor);
+					if(entry.isActive()){
+						entry.setActive(false);
+					}
 				} else if(bufferListAdapter.networks.getNetworkById(entry.getInfo().networkId).getUserByNick(nick).away) {
 					holder.bufferImage.setImageBitmap(userAwayBitmap);
 				} else {
 					holder.bufferImage.setImageBitmap(userBitmap);
+					if(!entry.isActive()){
+						entry.setActive(true);
+					}
 				}
 
 				holder.bufferView.setText(nick);


### PR DESCRIPTION
This patch sets the status of query buffers based on whether or not the user is present, away, or gone.  The old code only set the color if the user was Gone, but this didn't even work because the regular color-picking code overrode the query-specific code.  Additionally, the old code would not have matched the selected theme, had it worked at all.
