### PR TITLE
Add "[]" around the nick in NOTICE messages to match the formatting used by regular Quassel.

### DIFF
--- a/QuasselDroid/src/main/java/com/iskrembilen/quasseldroid/gui/fragments/ChatFragment.java
+++ b/QuasselDroid/src/main/java/com/iskrembilen/quasseldroid/gui/fragments/ChatFragment.java
@@ -405,7 +405,7 @@ public class ChatFragment extends SherlockFragment {
 				holder.msgView.setText(entry.content);
 				break;
 			case Notice:
-				holder.nickView.setText(entry.getNick());
+				holder.nickView.setText("["+entry.getNick()+"]");
 				holder.msgView.setTextColor(ThemeUtil.chatNoticeColor);
 				holder.nickView.setTextColor(ThemeUtil.chatNoticeColor);
 				holder.msgView.setText(entry.content);


### PR DESCRIPTION
Pretty much self-explanatory.  Quassel puts "[]" around the nick for NOTICE messages and quasseldroid doesn't.
