### PR TITLE
Make each Network observe its own statusBuffer.

### DIFF
--- a/QuasselDroid/src/main/java/com/iskrembilen/quasseldroid/Network.java
+++ b/QuasselDroid/src/main/java/com/iskrembilen/quasseldroid/Network.java
@@ -60,6 +60,7 @@ public class Network extends Observable implements Observer, Comparable<Network>
 
 	public void setStatusBuffer(Buffer statusBuffer) {
 		this.statusBuffer = statusBuffer;
+        statusBuffer.addObserver(this);
 		this.setChanged();
 		notifyObservers();
 	}


### PR DESCRIPTION
This fixes the issue where new messages in a status buffer did not cause the network name in BufferFragment to change color as it should.
