### PR TITLE
Set query buffers as active when the user is away too.

### DIFF
--- a/QuasselDroid/src/main/java/com/iskrembilen/quasseldroid/gui/fragments/BufferFragment.java
+++ b/QuasselDroid/src/main/java/com/iskrembilen/quasseldroid/gui/fragments/BufferFragment.java
@@ -462,6 +462,9 @@ public class BufferFragment extends SherlockFragment implements OnGroupExpandLis
 					}
 				} else if(bufferListAdapter.networks.getNetworkById(entry.getInfo().networkId).getUserByNick(nick).away) {
 					holder.bufferImage.setImageBitmap(userAwayBitmap);
+                    if(!entry.isActive()){
+                        entry.setActive(true);
+                    }
 				} else {
 					holder.bufferImage.setImageBitmap(userBitmap);
 					if(!entry.isActive()){


### PR DESCRIPTION
I missed this condition in my previous bugfix for query buffers, which caused the icon to show as "away" but the icon as "parted."
