### PR TITLE
Send requests for user and channel init data out of CoreConnService

### DIFF
--- a/QuasselDroid/src/main/java/com/iskrembilen/quasseldroid/io/CoreConnection.java
+++ b/QuasselDroid/src/main/java/com/iskrembilen/quasseldroid/io/CoreConnection.java
@@ -650,7 +650,7 @@ public final class CoreConnection {
 	 * @param className The class name of the object we want.
 	 * @param objectName The name of the object we want.
 	 */
-	private void sendInitRequest(String className, String objectName) throws IOException {
+	public void sendInitRequest(String className, String objectName) throws IOException {
 		List<QVariant<?>> packedFunc = new LinkedList<QVariant<?>>();
 		packedFunc.add(new QVariant<Integer>(RequestType.InitRequest.getValue(), QVariantType.Int));
 		packedFunc.add(new QVariant<String>(className, QVariantType.String));
@@ -1202,10 +1202,10 @@ public final class CoreConnection {
 							//If not done then we can add it right here, if we try to send it we might crash because service don't have the network yet
 							if(!initComplete) { 
 								networks.get(Integer.parseInt(objectName)).onUserJoined(user);
+                                sendInitRequest("IrcUser", objectName+"/" + nick.split("!")[0]);
 							} else {
 								service.getHandler().obtainMessage(R.id.NEW_USER_ADDED, Integer.parseInt(objectName), 0, user).sendToTarget();
 							}
-							sendInitRequest("IrcUser", objectName+"/" + nick.split("!")[0]);
 						}  else if (className.equals("Network") && function.equals("setConnectionState")) {
 							Log.d(TAG, "Sync: Network -> setConnectionState");
 							int networkId = Integer.parseInt(objectName);
@@ -1229,7 +1229,6 @@ public final class CoreConnection {
 							Log.d(TAG, "Sync: Network -> addIrcChannel");
 							int networkId = Integer.parseInt(objectName);
 							String bufferName = (String) packedFunc.remove(0).getData();
-							System.out.println(bufferName);
 							boolean hasBuffer = false;
 							for(Buffer buffer : networks.get(networkId).getBuffers().getRawBufferList()) {
 								if(buffer.getInfo().name.equalsIgnoreCase(bufferName)) {
@@ -1250,7 +1249,6 @@ public final class CoreConnection {
 								Message msg = service.getHandler().obtainMessage(R.id.NEW_BUFFER_TO_SERVICE, buffer);
 								msg.sendToTarget();
 							}
-							sendInitRequest("IrcChannel", objectName+"/" + bufferName);	
 						} 
 						else if (className.equals("Network") && function.equals("setConnected")) {
 							Log.d(TAG, "Sync: Network -> setConnected");

--- a/QuasselDroid/src/main/java/com/iskrembilen/quasseldroid/service/CoreConnService.java
+++ b/QuasselDroid/src/main/java/com/iskrembilen/quasseldroid/service/CoreConnService.java
@@ -79,6 +79,7 @@ import com.iskrembilen.quasseldroid.util.QuasseldroidNotificationManager;
 import com.squareup.otto.Produce;
 import com.squareup.otto.Subscribe;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Observer;
@@ -385,6 +386,11 @@ public class CoreConnService extends Service {
 				 */
 				networks.addBuffer((Buffer) msg.obj);
                 checkSwitchingTo((Buffer) msg.obj);
+                try{
+                    coreConn.sendInitRequest("IrcChannel", ((Buffer) msg.obj).getInfo().networkId+"/" + ((Buffer) msg.obj).getInfo().name);
+                }catch(IOException e){
+                    e.printStackTrace();
+                }
 				break;
 			case R.id.ADD_MULTIPLE_BUFFERS:
 				/**
@@ -465,6 +471,11 @@ public class CoreConnService extends Service {
 				 */
 				user = (IrcUser) msg.obj;
 				networks.getNetworkById(msg.arg1).onUserJoined(user);
+                try{
+                    coreConn.sendInitRequest("IrcUser", msg.arg1+"/" + user.nick.split("!")[0]);
+                }catch(IOException e){
+                    e.printStackTrace();
+                }
 				break;
 			case R.id.NEW_USER_INFO:
 				bundle = (Bundle) msg.obj;


### PR DESCRIPTION
This prevents a race condition where the initdata would often arrive before the channel or user had been added to the appropriate lists, causing the channel or user data to be lost.
