### PR TITLE
Fix a few more crashes.

### DIFF
--- a/QuasselDroid/src/main/java/com/iskrembilen/quasseldroid/io/CoreConnection.java
+++ b/QuasselDroid/src/main/java/com/iskrembilen/quasseldroid/io/CoreConnection.java
@@ -920,7 +920,7 @@ public final class CoreConnection {
 									}
 								}
 								if(!foundChannel) 
-									throw new RuntimeException("A channel in a network has no coresponding buffer object " + chanName);
+									Log.e(TAG, "A channel in a network has no coresponding buffer object " + chanName);
 							}
 							
 							Log.i(TAG, "Sending network " + network.getName() + " to service");

--- a/QuasselDroid/src/main/java/com/iskrembilen/quasseldroid/service/CoreConnService.java
+++ b/QuasselDroid/src/main/java/com/iskrembilen/quasseldroid/service/CoreConnService.java
@@ -596,7 +596,6 @@ public class CoreConnService extends Service {
 				}
 				//Did not find buffer in the network, something is wrong
 				Log.w(TAG, "joinIrcUser: Did not find buffer with name " + bufferName);
-				throw new RuntimeException("joinIrcUser: Did not find buffer with name " + bufferName);
 			case R.id.USER_CHANGEDNICK:
 				if (networks.getNetworkById(msg.arg1) == null) {
 					Log.e(TAG, "Could not find network with id " + msg.arg1 + " for changing a user nick");
@@ -800,8 +799,12 @@ public class CoreConnService extends Service {
 	
 	@Subscribe
 	public void getGetBacklog(GetBacklogEvent event) {
-		Log.d(TAG, "Fetching more backlog");
-		coreConn.requestMoreBacklog(event.bufferId, event.backlogAmount);
+        if(event!=null){
+            Log.d(TAG, "Fetching more backlog");
+            coreConn.requestMoreBacklog(event.bufferId, event.backlogAmount);
+        }else{
+            Log.e(TAG, "Cannot request backlog, event was null!");
+        }
 	}
 	
 	@Subscribe

--- a/QuasselDroid/src/main/java/com/iskrembilen/quasseldroid/util/StringReaderUtil.java
+++ b/QuasselDroid/src/main/java/com/iskrembilen/quasseldroid/util/StringReaderUtil.java
@@ -21,6 +21,8 @@
 
 package com.iskrembilen.quasseldroid.util;
 
+import android.util.Log;
+
 import com.iskrembilen.quasseldroid.qtcomm.QDataInputStream;
 
 import java.io.IOException;
@@ -36,6 +38,8 @@ import java.nio.charset.CharsetDecoder;
  * 
  */
 public class StringReaderUtil {
+    private static final String TAG = StringReaderUtil.class.getSimpleName();
+
 	int buflen = -1;
 	ByteBuffer buf;
 	CharsetDecoder decoder;
@@ -71,7 +75,12 @@ public class StringReaderUtil {
 		stream.readFully(buf.array(), 0, len);
 		
 		//Decode it with correct encoding
-		decoder.decode(buf, charBuffer, false);
+        try{
+		    decoder.decode(buf, charBuffer, false);
+        }catch(IllegalArgumentException e){
+            e.printStackTrace();
+            Log.e(TAG, "Failed to decode buffer: " + buf);
+        }
 		
 		//Set where the current string ends, it is the position we are at after decoding into the buffer
 		charBuffer.limit(charBuffer.position());


### PR DESCRIPTION
One has to do with the string decoder.  In that case, just return an empty string and print the offending characters to the log.  The other has to do with a backlog request event being null.  In that case, just ignore the request.  The last was discovered by running IRCfuzz.c and was fixed by not throwing exceptions from CoreConnService.
