### PR TITLE
Fix unhiding of temporarily-hidden buffers.

### DIFF
--- a/QuasselDroid/src/main/java/com/iskrembilen/quasseldroid/service/CoreConnService.java
+++ b/QuasselDroid/src/main/java/com/iskrembilen/quasseldroid/service/CoreConnService.java
@@ -371,7 +371,7 @@ public class CoreConnService extends Service {
 					}
 					buffer.addMessage(message);
 					
-					if (buffer.isTemporarilyHidden()) {
+					if (buffer.isTemporarilyHidden() && (message.type==IrcMessage.Type.Plain || message.type==IrcMessage.Type.Notice || message.type==IrcMessage.Type.Action)) {
 						unhideTempHiddenBuffer(buffer.getInfo().id);
 					}
 				} else {


### PR DESCRIPTION
Buffers should unhide only on Plain, Notice, or Action messages.
