### PR TITLE
Fix crash when rotating while connecting.

### DIFF
--- a/QuasselDroid/src/main/java/com/iskrembilen/quasseldroid/gui/MainActivity.java
+++ b/QuasselDroid/src/main/java/com/iskrembilen/quasseldroid/gui/MainActivity.java
@@ -146,10 +146,6 @@ public class MainActivity extends SherlockFragmentActivity {
             if (fragment.getClass() == ChatFragment.class) {
                 chatFragment = fragment;
             }
-        } else {
-            chatFragment = ChatFragment.newInstance();
-            nickFragment = NickListFragment.newInstance();
-            bufferFragment = BufferFragment.newInstance();
         }
 
         preferences = PreferenceManager.getDefaultSharedPreferences(getApplicationContext());
@@ -196,7 +192,9 @@ public class MainActivity extends SherlockFragmentActivity {
                 if (drawerFragment != null) drawerFragment.setMenuVisibility(true);
                 if (chatFragment != null) chatFragment.setMenuVisibility(false);
 
-                hideKeyboard(bufferFragment.getView());
+                if (bufferFragment != null) {
+                    hideKeyboard(bufferFragment.getView());
+                }
 
                 getSupportActionBar().setTitle(getResources().getString(R.string.app_name));
                 invalidateOptionsMenu();
@@ -370,6 +368,10 @@ public class MainActivity extends SherlockFragmentActivity {
         Fragment currentFragment = manager.findFragmentById(R.id.main_content_container);
         if (event.done) {
             if (currentFragment == null || currentFragment.getClass() != ChatFragment.class) {
+                chatFragment = ChatFragment.newInstance();
+                nickFragment = NickListFragment.newInstance();
+                bufferFragment = BufferFragment.newInstance();
+
                 FragmentTransaction trans = manager.beginTransaction();
                 trans.replace(R.id.main_content_container, chatFragment);
 


### PR DESCRIPTION
When being created, the MainActivity restores its references to the fragments using the FragmentManager, which looks up the fragments currently being displayed in the three positions.  However, the fragments are not actually set into these positions until the connection is complete.  Because of this, if the user rotates the device and causes the MainActivity to be destroyed and recreated, the references to the old fragments are lost.  This causes a crash when later attempting to display the fragments.  The solution is to initialize the fragments immediately before displaying them.  Additionally, a check needs to be added before hiding the keyboard using a reference to the chatFragment.  This won't cause a change in functionality because the keyboard can only be displayed once the chat fragment is actually populated with a chat, and the chat fragment cannot become populated with a chat until after the connection is already complete.
