### PR TITLE
Stack chat ListView from bottom.

### DIFF
--- a/QuasselDroid/src/main/res/layout/chat_fragment_layout.xml
+++ b/QuasselDroid/src/main/res/layout/chat_fragment_layout.xml
@@ -41,7 +41,8 @@
         android:layout_below="@+id/chat_topic_frame"
         android:divider="@null"
         android:dividerHeight="0dp"
-        android:transcriptMode="normal" />
+        android:transcriptMode="normal"
+        android:stackFromBottom="true" />
 
     <FrameLayout
         android:id="@+id/R.id.chat_input_frame"


### PR DESCRIPTION
Displaying chat lists that don't fill the whole screen starting at the bottom more accurately reflects how regular Quassel does it.
