### PR TITLE
Fix backlog request with size greater than remaining backlog.

### DIFF
--- a/QuasselDroid/src/main/java/com/iskrembilen/quasseldroid/gui/fragments/ChatFragment.java
+++ b/QuasselDroid/src/main/java/com/iskrembilen/quasseldroid/gui/fragments/ChatFragment.java
@@ -71,7 +71,7 @@ public class ChatFragment extends SherlockFragment {
     private TextView topicView;
     private TextView topicViewFull;
     private ImageButton autoCompleteButton;
-    private int dynamicBacklogAmout;
+    private int dynamicBacklogAmount;
     private NickCompletionHelper nickCompletionHelper;
     private int bufferId = -1;
 
@@ -200,7 +200,7 @@ public class ChatFragment extends SherlockFragment {
     @Override
     public void onStart() {
         super.onStart();
-        dynamicBacklogAmout = Integer.parseInt(preferences.getString(getString(R.string.preference_dynamic_backlog), "10"));
+        dynamicBacklogAmount = Integer.parseInt(preferences.getString(getString(R.string.preference_dynamic_backlog), "10"));
         autoCompleteButton.setEnabled(false);
         inputField.setEnabled(false);
         BusProvider.getInstance().register(this);
@@ -561,8 +561,8 @@ public class ChatFragment extends SherlockFragment {
         }
 
         public void getMoreBacklog() {
-            adapter.buffer.setBacklogPending(dynamicBacklogAmout);
-            BusProvider.getInstance().post(new GetBacklogEvent(adapter.getBufferId(), dynamicBacklogAmout));
+            adapter.buffer.setBacklogPending(true);
+            BusProvider.getInstance().post(new GetBacklogEvent(adapter.getBufferId(), dynamicBacklogAmount));
         }
 
         public void removeFilter(Type type) {

--- a/QuasselDroid/src/main/java/com/iskrembilen/quasseldroid/io/CoreConnection.java
+++ b/QuasselDroid/src/main/java/com/iskrembilen/quasseldroid/io/CoreConnection.java
@@ -1220,12 +1220,13 @@ public final class CoreConnection {
                                     }
                                 } else {
                                     // Send our the backlog messages to our listeners
-                                    //TODO: bundle them up before sending to save message objects
+                                    List<IrcMessage> messageList = new ArrayList<IrcMessage>();
                                     for (QVariant<?> message : data) {
-                                        Message msg = service.getHandler().obtainMessage(R.id.NEW_BACKLOGITEM_TO_SERVICE);
-                                        msg.obj = message.getData();
-                                        msg.sendToTarget();
+                                        messageList.add((IrcMessage) message.getData());
                                     }
+                                    Message msg = service.getHandler().obtainMessage(R.id.NEW_BACKLOGITEM_TO_SERVICE);
+                                    msg.obj = messageList;
+                                    msg.sendToTarget();
                                 }
 							/* 
 							 * The addIrcUser function in the Network class is called whenever a new


### PR DESCRIPTION
Before, backlog would only be added to the buffer after receiving the full amount requested.  However, this would not work properly if the buffer didn't have the requested amount of backlog.  In that case, none of the requested backlog would ever be displayed.  This fixes the issue by adding all the received backlog to a single list at the CoreConnection level so that it is not necessary to keep a backlog stash in the buffer itself.
