### PR TITLE
Initialize Buffer topic to the empty string.

### DIFF
--- a/QuasselDroid/src/main/java/com/iskrembilen/quasseldroid/Buffer.java
+++ b/QuasselDroid/src/main/java/com/iskrembilen/quasseldroid/Buffer.java
@@ -77,7 +77,7 @@ public class Buffer extends Observable implements Comparable<Buffer> {
     /**
      * The topic for this buffer
      */
-    private String topic;
+    private String topic = "";
     /**
      * Is this buffer joined or parted.
      */


### PR DESCRIPTION
This prevents the topic showing as "null" on parted buffers.
