### PR TITLE
Send real ClientVersion.

### DIFF
--- a/QuasselDroid/src/main/java/com/iskrembilen/quasseldroid/io/CoreConnection.java
+++ b/QuasselDroid/src/main/java/com/iskrembilen/quasseldroid/io/CoreConnection.java
@@ -384,7 +384,7 @@ public final class CoreConnection {
         Date date = new Date();
         initial.put("ClientDate", new QVariant<String>(dateFormat.format(date), QVariantType.String));
         initial.put("UseSsl", new QVariant<Boolean>(ssl, QVariantType.Bool));
-        initial.put("ClientVersion", new QVariant<String>("v0.6.1 (dist-<a href='http://git.quassel-irc.org/?p=quassel.git;a=commit;h=611ebccdb6a2a4a89cf1f565bee7e72bcad13ffb'>611ebcc</a>)", QVariantType.String));
+        initial.put("ClientVersion", new QVariant<String>("Quasseldroid " + service.getVersionName(), QVariantType.String));
         initial.put("UseCompression", new QVariant<Boolean>(false, QVariantType.Bool));
         initial.put("MsgType", new QVariant<String>("ClientInit", QVariantType.String));
         initial.put("ProtocolVersion", new QVariant<Integer>(10, QVariantType.Int));

--- a/QuasselDroid/src/main/java/com/iskrembilen/quasseldroid/service/CoreConnService.java
+++ b/QuasselDroid/src/main/java/com/iskrembilen/quasseldroid/service/CoreConnService.java
@@ -28,6 +28,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.SharedPreferences.OnSharedPreferenceChangeListener;
+import android.content.pm.PackageManager;
 import android.net.wifi.WifiManager;
 import android.net.wifi.WifiManager.WifiLock;
 import android.os.Binder;
@@ -714,6 +715,14 @@ public class CoreConnService extends Service {
 
     public Network getNetworkById(int networkId) {
         return networks.getNetworkById(networkId);
+    }
+
+    public String getVersionName(){
+        try{
+            return getPackageManager().getPackageInfo(getPackageName(), 0).versionName;
+        }catch(PackageManager.NameNotFoundException e){
+            return "";
+        }
     }
 
     private void checkSwitchingTo(Buffer buffer) {


### PR DESCRIPTION
Send "Quasseldroid" and the version number instead of sending a fake version string from an old Quassel.
