### PR TITLE
Restore chat textbox to old behavior.

### DIFF
--- a/QuasselDroid/src/main/res/layout/chat_fragment_layout.xml
+++ b/QuasselDroid/src/main/res/layout/chat_fragment_layout.xml
@@ -55,7 +55,7 @@
             android:layout_width="fill_parent"
             android:layout_height="wrap_content"
             android:imeOptions="actionSend"
-            android:inputType="textImeMultiLine"
+            android:inputType="textImeMultiLine|textCapSentences|textAutoCorrect"
             android:paddingLeft="36dp"></EditText>
 
         <ImageButton


### PR DESCRIPTION
This adds the textCapSentences and textAutoCorrect IMEs to the
chat text input box, restoring the functionality of said box
to what it was before the IME was changed to work around the
no-Send bug introduced by the switch to API 19.
