### PR TITLE
Fix the message displayed on changing one's own nick.

### DIFF
--- a/QuasselDroid/src/main/java/com/iskrembilen/quasseldroid/gui/fragments/ChatFragment.java
+++ b/QuasselDroid/src/main/java/com/iskrembilen/quasseldroid/gui/fragments/ChatFragment.java
@@ -464,7 +464,11 @@ public class ChatFragment extends SherlockFragment {
                     break;
                 case Nick:
                     holder.nickView.setText("<->");
-                    holder.msgView.setText(entry.getNick() + " is now known as " + entry.content.toString());
+                    if(entry.getNick().equals(entry.content.toString())){
+                        holder.msgView.setText("You are now known as " + entry.content.toString());
+                    }else{
+                        holder.msgView.setText(entry.getNick() + " is now known as " + entry.content.toString());
+                    }
                     holder.msgView.setTextColor(ThemeUtil.chatNickColor);
                     holder.nickView.setTextColor(ThemeUtil.chatNickColor);
                     break;


### PR DESCRIPTION
If the nick associated with the entry is the same as the nick
being changed to, then the nick change message is for the current
user and should be displayed as such.
