### PR TITLE
Add support for the new handshake and for streaming compression.

### DIFF
--- a/QuasselDroid/src/main/java/com/iskrembilen/quasseldroid/gui/LoginActivity.java
+++ b/QuasselDroid/src/main/java/com/iskrembilen/quasseldroid/gui/LoginActivity.java
@@ -236,7 +236,6 @@ public class LoginActivity extends SherlockFragmentActivity implements Observer,
                 ((EditText) dialog.findViewById(R.id.dialog_name_field)).setText(res.getString(QuasselDbHelper.KEY_NAME));
                 ((EditText) dialog.findViewById(R.id.dialog_address_field)).setText(res.getString(QuasselDbHelper.KEY_ADDRESS));
                 ((EditText) dialog.findViewById(R.id.dialog_port_field)).setText(Integer.toString(res.getInt(QuasselDbHelper.KEY_PORT)));
-                ((CheckBox) dialog.findViewById(R.id.dialog_usessl_checkbox)).setChecked(res.getBoolean(QuasselDbHelper.KEY_SSL));
                 break;
         }
 
@@ -262,12 +261,10 @@ public class LoginActivity extends SherlockFragmentActivity implements Observer,
                         EditText nameField = (EditText) dialog.findViewById(R.id.dialog_name_field);
                         EditText addressField = (EditText) dialog.findViewById(R.id.dialog_address_field);
                         EditText portField = (EditText) dialog.findViewById(R.id.dialog_port_field);
-                        CheckBox sslBox = (CheckBox) dialog.findViewById(R.id.dialog_usessl_checkbox);
                         if (v.getId() == R.id.cancel_button) {
                             nameField.setText("");
                             addressField.setText("");
                             portField.setText("");
-                            sslBox.setChecked(false);
                             dialog.dismiss();
 
 
@@ -275,19 +272,17 @@ public class LoginActivity extends SherlockFragmentActivity implements Observer,
                             String name = nameField.getText().toString().trim();
                             String address = addressField.getText().toString().trim();
                             int port = Integer.parseInt(portField.getText().toString().trim());
-                            boolean useSSL = sslBox.isChecked();
 
                             //TODO: Ken: mabye add some better check on what state the dialog is used for, edit/add. Atleast use a string from the resources so its the same if you change it.
                             if ((String) dialog.getWindow().getAttributes().getTitle() == "Add new core") {
-                                dbHelper.addCore(name, address, port, useSSL);
+                                dbHelper.addCore(name, address, port);
                             } else if ((String) dialog.getWindow().getAttributes().getTitle() == "Edit core") {
-                                dbHelper.updateCore(core.getSelectedItemId(), name, address, port, useSSL);
+                                dbHelper.updateCore(core.getSelectedItemId(), name, address, port);
                             }
                             LoginActivity.this.updateCoreSpinner();
                             nameField.setText("");
                             addressField.setText("");
                             portField.setText("");
-                            sslBox.setChecked(false);
                             dialog.dismiss();
                             if ((String) dialog.getWindow().getAttributes().getTitle() == "Add new core") {
                                 Toast.makeText(LoginActivity.this, "Added core", Toast.LENGTH_LONG).show();
@@ -379,7 +374,6 @@ public class LoginActivity extends SherlockFragmentActivity implements Observer,
             connectIntent.putExtra("name", res.getString(QuasselDbHelper.KEY_NAME));
             connectIntent.putExtra("address", res.getString(QuasselDbHelper.KEY_ADDRESS));
             connectIntent.putExtra("port", res.getInt(QuasselDbHelper.KEY_PORT));
-            connectIntent.putExtra("ssl", res.getBoolean(QuasselDbHelper.KEY_SSL));
             connectIntent.putExtra("username", usernameField.getText().toString().trim());
             connectIntent.putExtra("password", passwordField.getText().toString());
 

--- a/QuasselDroid/src/main/java/com/iskrembilen/quasseldroid/io/CoreConnection.java
+++ b/QuasselDroid/src/main/java/com/iskrembilen/quasseldroid/io/CoreConnection.java
@@ -22,12 +22,14 @@
 package com.iskrembilen.quasseldroid.io;
 
 import android.content.SharedPreferences;
+import android.os.Build;
 import android.os.Bundle;
 import android.os.CountDownTimer;
 import android.os.Message;
 import android.preference.PreferenceManager;
 import android.util.Log;
 import android.util.Pair;
+import android.widget.AbsListView;
 
 import com.iskrembilen.quasseldroid.Buffer;
 import com.iskrembilen.quasseldroid.BufferCollection;
@@ -86,6 +88,8 @@ public final class CoreConnection {
     private Socket socket;
     private QDataOutputStream outStream;
     private QDataInputStream inStream;
+    private SwitchableDeflaterOutputStream deflater;
+    private SwitchableInflaterInputStream inflater;
 
     private Map<Integer, Buffer> buffers;
     private CoreInfo coreInfo;
@@ -96,7 +100,6 @@ public final class CoreConnection {
     private int port;
     private String username;
     private String password;
-    private boolean ssl;
 
     CoreConnService service;
     private Timer heartbeatTimer;
@@ -112,17 +115,19 @@ public final class CoreConnection {
     //Used to create the ID of new channels we join
     private int maxBufferId = 0;
 
+    private boolean usingSSL = false;
+    private boolean usingCompression = false;
+
     private ExecutorService outputExecutor;
 
 
     public CoreConnection(long coreId, String address, int port, String username,
-                          String password, Boolean ssl, CoreConnService parent) {
+                          String password, CoreConnService parent) {
         this.coreId = coreId;
         this.address = address;
         this.port = port;
         this.username = username;
         this.password = password;
-        this.ssl = ssl;
         this.service = parent;
 
         outputExecutor = Executors.newSingleThreadExecutor();
@@ -374,7 +379,67 @@ public final class CoreConnection {
         socket = (Socket) factory.createSocket(address, port);
         socket.setKeepAlive(true);
         outStream = new QDataOutputStream(socket.getOutputStream());
+        inStream = new QDataInputStream(socket.getInputStream());
         // END CREATE SOCKETS
+
+        updateInitProgress("Attempting new-style handshake...");
+
+        //Calculate and send magic value
+        long magic = 0x42b33f00;
+        magic = magic | 0x01;   //0x01 is encryption
+
+        //DeflaterOutputStream SYNC_FLUSH support is required for compression, but Eclair doesn't support that.
+        if (Build.VERSION.SDK_INT > Build.VERSION_CODES.ECLAIR_MR1) {
+            magic = magic | 0x02;   //0x02 is compression
+        } else {
+            Log.d(TAG, "Android version is too old, disabling compression.  Please update to 2.2 or later.");
+        }
+
+        outStream.writeUInt(magic, 32);
+
+        //Send supported protocols
+        outStream.writeUInt(0x01, 32);      //0x01 is Legacy Protocol
+        outStream.writeUInt(0x01 << 31, 32); //Bit 31 set to indicate end of list
+
+        //Attempt to read core's response
+        try {
+            long responseValue = inStream.readUInt(32);
+
+            //Check to make sure legacy protocol is in use
+            if ((responseValue & 0x01) == 0) {
+                throw new UnsupportedProtocolException("Core claims not to support legacy protocol!");
+            }
+
+            //Check if Encryption should be used
+            if (((responseValue >> 24) & 0x01) > 0) {
+                usingSSL = true;
+            }
+
+            //Check if Compression should be used
+            if (((responseValue >> 24) & 0x02) > 0) {
+                if (Build.VERSION.SDK_INT > Build.VERSION_CODES.ECLAIR_MR1) {
+                    usingCompression = true;
+                } else {
+                    throw new UnsupportedProtocolException("Core is forcing compression, but compression is unsupported!");
+                }
+            }
+        } catch (IOException e) {
+            //This means that the core supports only the legacy handshake, so reopen the connection
+            //and try again.
+            updateInitProgress("Legacy core detected, falling back to legacy handshake...");
+            socket = (Socket) factory.createSocket(address, port);
+            socket.setKeepAlive(true);
+            outStream = new QDataOutputStream(socket.getOutputStream());
+            inStream = new QDataInputStream(socket.getInputStream());
+        }
+
+        if (usingCompression) {
+            Log.d(TAG, "Using compression.");
+            deflater = new SwitchableDeflaterOutputStream(socket.getOutputStream());
+            inflater = new SwitchableInflaterInputStream(socket.getInputStream());
+            outStream = new QDataOutputStream(deflater);
+            inStream = new QDataInputStream(inflater);
+        }
 
         // START CLIENT INFO
         updateInitProgress("Sending client info...");
@@ -383,7 +448,7 @@ public final class CoreConnection {
         DateFormat dateFormat = new SimpleDateFormat("MMM dd yyyy HH:mm:ss");
         Date date = new Date();
         initial.put("ClientDate", new QVariant<String>(dateFormat.format(date), QVariantType.String));
-        initial.put("UseSsl", new QVariant<Boolean>(ssl, QVariantType.Bool));
+        initial.put("UseSsl", new QVariant<Boolean>(true, QVariantType.Bool));
         initial.put("ClientVersion", new QVariant<String>("Quasseldroid " + service.getVersionName(), QVariantType.String));
         initial.put("UseCompression", new QVariant<Boolean>(false, QVariantType.Bool));
         initial.put("MsgType", new QVariant<String>("ClientInit", QVariantType.String));
@@ -394,7 +459,6 @@ public final class CoreConnection {
 
         // START CORE INFO
         updateInitProgress("Getting core info...");
-        inStream = new QDataInputStream(socket.getInputStream());
         Map<String, QVariant<?>> reply = readQVariantMap();
         if(reply.get("MsgType").toString().equals("ClientInitAck")){
             coreInfo = new CoreInfo();
@@ -413,33 +477,39 @@ public final class CoreConnection {
             }
         }
 
+        if (!usingSSL && coreInfo.isSupportSsl()) {
+            usingSSL = true;
+        }
+
         //Check that the protocol version is at least 10
         if (coreInfo.getProtocolVersion() < 10)
             throw new UnsupportedProtocolException("Protocol version is old: " + coreInfo.getProtocolVersion());
-        /*for (String key : reply.keySet()) {
-			System.out.println("\t" + key + " : " + reply.get(key));
-		}*/
         // END CORE INFO
 
         // START SSL CONNECTION
-        if (ssl) {
-            Log.d(TAG, "Using ssl");
+        if (usingSSL) {
+            Log.d(TAG, "Using SSL.");
             SSLContext sslContext = SSLContext.getInstance("TLS");
             TrustManager[] trustManagers = new TrustManager[]{new CustomTrustManager(this)};
             sslContext.init(null, trustManagers, null);
             SSLSocketFactory sslSocketFactory = sslContext.getSocketFactory();
             SSLSocket sslSocket = (SSLSocket) sslSocketFactory.createSocket(socket, address, port, true);
-            sslSocket.setEnabledProtocols(new String[]{"SSLv3"});
 
             sslSocket.setUseClientMode(true);
-            updateInitProgress("Starting ssl handshake");
+            updateInitProgress("Starting SSL handshake...");
             sslSocket.startHandshake();
-            Log.d(TAG, "Ssl handshake complete");
-            inStream = new QDataInputStream(sslSocket.getInputStream());
-            outStream = new QDataOutputStream(sslSocket.getOutputStream());
+            Log.d(TAG, "SSL handshake complete.");
+
+            if (usingCompression) {
+                deflater.setOutputStream(sslSocket.getOutputStream());
+                inflater.setInputStream(sslSocket.getInputStream());
+            } else {
+                outStream = new QDataOutputStream(sslSocket.getOutputStream());
+                inStream = new QDataInputStream(sslSocket.getInputStream());
+            }
             socket = sslSocket;
         } else {
-            Log.w(TAG, "SSL DISABLED!");
+            Log.w(TAG, "Core does not support SSL!");
         }
         // FINISHED SSL CONNECTION
 
@@ -628,6 +698,9 @@ public final class CoreConnection {
 
                 // Send data
                 outStream.write(baos.toByteArray());
+                if (usingCompression) {
+                    deflater.flush();
+                }
                 bos.close();
                 baos.close();
             } catch (IOException e) {

--- a/QuasselDroid/src/main/java/com/iskrembilen/quasseldroid/io/SwitchableDeflaterOutputStream.java
+++ b/QuasselDroid/src/main/java/com/iskrembilen/quasseldroid/io/SwitchableDeflaterOutputStream.java
@@ -1,0 +1,36 @@
+/**
+ QuasselDroid - Quassel client for Android
+ Copyright (C) 2011 Martin Sandsmark <martin.sandsmark@kde.org>
+
+ This program is free software: you can redistribute it and/or modify it
+ under the terms of the GNU General Public License as published by the Free
+ Software Foundation, either version 3 of the License, or (at your option)
+ any later version, or under the terms of the GNU Lesser General Public
+ License as published by the Free Software Foundation; either version 2.1 of
+ the License, or (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License and the
+ GNU Lesser General Public License along with this program.  If not, see
+ <http://www.gnu.org/licenses/>.
+ */
+
+package com.iskrembilen.quasseldroid.io;
+
+import java.io.OutputStream;
+import java.util.zip.DeflaterOutputStream;
+
+public class SwitchableDeflaterOutputStream extends DeflaterOutputStream{
+
+    public SwitchableDeflaterOutputStream(OutputStream os) {
+        super(os, true);
+    }
+
+    public void setOutputStream(OutputStream os){
+        out = os;
+    }
+}

--- a/QuasselDroid/src/main/java/com/iskrembilen/quasseldroid/io/SwitchableInflaterInputStream.java
+++ b/QuasselDroid/src/main/java/com/iskrembilen/quasseldroid/io/SwitchableInflaterInputStream.java
@@ -1,0 +1,36 @@
+/**
+ QuasselDroid - Quassel client for Android
+ Copyright (C) 2011 Martin Sandsmark <martin.sandsmark@kde.org>
+
+ This program is free software: you can redistribute it and/or modify it
+ under the terms of the GNU General Public License as published by the Free
+ Software Foundation, either version 3 of the License, or (at your option)
+ any later version, or under the terms of the GNU Lesser General Public
+ License as published by the Free Software Foundation; either version 2.1 of
+ the License, or (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License and the
+ GNU Lesser General Public License along with this program.  If not, see
+ <http://www.gnu.org/licenses/>.
+ */
+
+package com.iskrembilen.quasseldroid.io;
+
+import java.io.InputStream;
+import java.util.zip.InflaterInputStream;
+
+public class SwitchableInflaterInputStream extends InflaterInputStream {
+
+    public SwitchableInflaterInputStream(InputStream is) {
+        super(is);
+    }
+
+    public void setInputStream(InputStream is){
+        in = is;
+    }
+}

--- a/QuasselDroid/src/main/java/com/iskrembilen/quasseldroid/service/CoreConnService.java
+++ b/QuasselDroid/src/main/java/com/iskrembilen/quasseldroid/service/CoreConnService.java
@@ -232,8 +232,7 @@ public class CoreConnService extends Service {
 
         acquireWakeLockIfEnabled();
 
-        coreConn = new CoreConnection(id, address, port, username, password, ssl,
-                this);
+        coreConn = new CoreConnection(id, address, port, username, password, this);
     }
 
     private void acquireWakeLockIfEnabled() {

--- a/QuasselDroid/src/main/res/layout/dialog_add_core.xml
+++ b/QuasselDroid/src/main/res/layout/dialog_add_core.xml
@@ -75,12 +75,6 @@
             </TableRow>
         </TableLayout>
 
-        <CheckBox
-            android:id="@+id/dialog_usessl_checkbox"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="Use SSL?"></CheckBox>
-
         <LinearLayout
             android:id="@+id/LinearLayout01"
             android:layout_width="wrap_content"

--- a/QuasselDroid/src/main/res/layout/preferences.xml
+++ b/QuasselDroid/src/main/res/layout/preferences.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
 
     <PreferenceCategory android:title="Backlog Fetching">
 


### PR DESCRIPTION
A new handshake format was introduced in Quassel 0.10.  This patch
adds support for that.  Streaming compression support, which is
made possible by the new handshake, is also introduced.  All
legacy functionality (connecting to pre-0.10 cores and to cores
that don't support streaming compression and/or SSL) is preserved.
Additionally, support for enabling/disabling SSL in the core
creation dialog was removed because there is no reason not to use
SSL if it is available.

One unrelated change was made to preferences.xml because Android
Studio wouldn't stop yelling at me until I did.
