### PR TITLE
Fix "Receiving Backlog" after destroying and rebuilding activity.

### DIFF
--- a/QuasselDroid/src/main/java/com/iskrembilen/quasseldroid/io/CoreConnection.java
+++ b/QuasselDroid/src/main/java/com/iskrembilen/quasseldroid/io/CoreConnection.java
@@ -1219,7 +1219,7 @@ public final class CoreConnection {
                                         maxBufferId = id;
                                     }
                                     if (!buffers.containsKey(id)) {
-                                        System.err.println("got buffer info for non-existent buffer id: " + id);
+                                        Log.w(TAG, "Got buffer info for non-existent buffer id: " + id);
                                         continue;
                                     }
                                     Message msg = service.getHandler().obtainMessage(R.id.SET_BUFFER_ORDER);
@@ -1242,7 +1242,6 @@ public final class CoreConnection {
 
                                     order++;
                                 }
-                                updateInitProgress("Receiving backlog");
 
                             }
 						/*
@@ -1296,6 +1295,7 @@ public final class CoreConnection {
                                 Collections.reverse(data); // Apparently, we receive them in the wrong order
 
                                 if (!initComplete) { //We are still initializing backlog for the first time
+                                    updateInitProgress("Receiving backlog");
                                     boolean preferenceParseColors = PreferenceManager.getDefaultSharedPreferences(service).getBoolean(service.getString(R.string.preference_colored_text), false);
                                     for (QVariant<?> message : data) {
                                         IrcMessage msg = (IrcMessage) message.getData();

--- a/QuasselDroid/src/main/java/com/iskrembilen/quasseldroid/service/CoreConnService.java
+++ b/QuasselDroid/src/main/java/com/iskrembilen/quasseldroid/service/CoreConnService.java
@@ -571,7 +571,6 @@ public class CoreConnService extends Service {
                     BusProvider.getInstance().post(new UnsupportedProtocolEvent());
                     break;
                 case R.id.INIT_PROGRESS:
-                    initDone = false;
                     initReason = (String) msg.obj;
                     BusProvider.getInstance().post(new InitProgressEvent(false, initReason));
                     break;


### PR DESCRIPTION
The problem was that every non-done init progress event was
re-setting the initDone boolean to false, causing it to think
the init was not complete when it actually was.  Additionally,
the updateInitProgress() call for "Receiving backlog" was
at the end of the code that processed BufferViewConfig events,
which became an inaccurate location after the hardcoded
bufferViewId was fixed.
