### PR TITLE
Fix multiple topic-updating issues.

### DIFF
--- a/QuasselDroid/src/main/java/com/iskrembilen/quasseldroid/Buffer.java
+++ b/QuasselDroid/src/main/java/com/iskrembilen/quasseldroid/Buffer.java
@@ -415,8 +415,9 @@ public class Buffer extends Observable implements Comparable<Buffer> {
      * @param topic the topic to set
      */
     public void setTopic(String topic) {
-        //TODO: notify observers
         this.topic = topic;
+        this.setChanged();
+        notifyObservers(R.id.BUFFERUPDATE_TOPICCHANGED);
     }
 
     /**

--- a/QuasselDroid/src/main/java/com/iskrembilen/quasseldroid/Network.java
+++ b/QuasselDroid/src/main/java/com/iskrembilen/quasseldroid/Network.java
@@ -90,6 +90,8 @@ public class Network extends Observable implements Observer, Comparable<Network>
 
     public void setName(String networkName) {
         this.networkName = networkName;
+
+        updateTopic();
     }
 
 
@@ -169,6 +171,8 @@ public class Network extends Observable implements Observer, Comparable<Network>
         userList.add(user);
         nickUserMap.put(user.nick, user);
         user.addObserver(this);
+
+        updateTopic();
     }
 
 
@@ -186,6 +190,8 @@ public class Network extends Observable implements Observer, Comparable<Network>
                 return;
             }
         }
+
+        updateTopic();
     }
 
 
@@ -205,6 +211,8 @@ public class Network extends Observable implements Observer, Comparable<Network>
                 break;
             }
         }
+
+        updateTopic();
     }
 
 
@@ -257,6 +265,8 @@ public class Network extends Observable implements Observer, Comparable<Network>
 
     public void setLatency(int latency) {
         this.latency = latency;
+
+        updateTopic();
     }
 
     public int getLatency() {
@@ -265,6 +275,8 @@ public class Network extends Observable implements Observer, Comparable<Network>
 
     public void setServer(String server) {
         this.server = server;
+
+        updateTopic();
     }
 
     public String getServer() {
@@ -273,6 +285,12 @@ public class Network extends Observable implements Observer, Comparable<Network>
 
     public int getCountUsers() {
         return userList.size();
+    }
+
+    private void updateTopic(){
+        if(statusBuffer!=null){
+            statusBuffer.setTopic("");
+        }
     }
 
 }

--- a/QuasselDroid/src/main/java/com/iskrembilen/quasseldroid/gui/fragments/ChatFragment.java
+++ b/QuasselDroid/src/main/java/com/iskrembilen/quasseldroid/gui/fragments/ChatFragment.java
@@ -319,6 +319,12 @@ public class ChatFragment extends SherlockFragment {
         public void setBuffer(Buffer buffer, NetworkCollection networks) {
             this.buffer = buffer;
             buffer.addObserver(this);
+            setTopic();
+            notifyDataSetChanged();
+            backlogList.scrollTo(backlogList.getScrollX(), backlogList.getScrollY());
+        }
+
+        public void setTopic(){
             String topic = "";
             if (buffer.getInfo().type == BufferInfo.Type.QueryBuffer) {
                 topic = buffer.getInfo().name;
@@ -334,8 +340,6 @@ public class ChatFragment extends SherlockFragment {
             }
             topicView.setText(topic);
             topicViewFull.setText(topic);
-            notifyDataSetChanged();
-            backlogList.scrollTo(backlogList.getScrollX(), backlogList.getScrollY());
         }
 
 
@@ -529,6 +533,10 @@ public class ChatFragment extends SherlockFragment {
                     int topId = getListTopMessageId();
                     notifyDataSetChanged();
                     setListTopMessage(topId);
+                    break;
+                case R.id.BUFFERUPDATE_TOPICCHANGED:
+                    setTopic();
+                    notifyDataSetChanged();
                     break;
                 default:
                     notifyDataSetChanged();

--- a/QuasselDroid/src/main/java/com/iskrembilen/quasseldroid/io/CoreConnection.java
+++ b/QuasselDroid/src/main/java/com/iskrembilen/quasseldroid/io/CoreConnection.java
@@ -1498,6 +1498,25 @@ public final class CoreConnection {
                                 bundle.putString("channel", channel);
 
                                 service.getHandler().obtainMessage(R.id.USER_REMOVE_MODE, networkId, 0, bundle).sendToTarget();
+                            } else if (className.equals("IrcChannel") && function.equals("setTopic")) {
+                                Log.d(TAG, "Sync: IrcChannel -> setTopic");
+                                String[] tmp = objectName.split("/", 2);
+                                int networkId = Integer.parseInt(tmp[0]);
+                                String bufferName = tmp[1];
+
+                                String topic = (String) packedFunc.remove(0).getData();
+                                boolean found = false;
+                                for (Buffer buffer : buffers.values()) {
+                                    if (buffer.getInfo().name.equalsIgnoreCase(bufferName) && buffer.getInfo().networkId == networkId) {
+                                        found = true;
+                                        Message msg = service.getHandler().obtainMessage(R.id.CHANNEL_TOPIC_CHANGED, networkId, buffer.getInfo().id, topic);
+                                        msg.sendToTarget();
+                                        break;
+                                    }
+                                }
+                                if (!found) {
+                                    Log.e(TAG, "Could not find buffer for IrcChannel setTopic");
+                                }
                             } else if (className.equals("BufferSyncer") && function.equals("setLastSeenMsg")) {
                                 Log.d(TAG, "Sync: BufferSyncer -> setLastSeenMsg");
                                 int bufferId = (Integer) packedFunc.remove(0).getData();

--- a/QuasselDroid/src/main/res/values/ids.xml
+++ b/QuasselDroid/src/main/res/values/ids.xml
@@ -36,6 +36,7 @@
     <item name="BUFFERUPDATE_BACKLOG" type="id"></item>
     <item name="BUFFERUPDATE_NEWMESSAGE" type="id"></item>
     <item name="BUFFERUPDATE_USERSCHANGED" type="id"></item>
+    <item name="BUFFERUPDATE_TOPICCHANGED" type="id"></item>
     <item name="DISCONNECTED" type="id"></item>
     <item name="SET_BUFFER_PERM_HIDDEN" type="id"></item>
     <item name="SET_BUFFER_TEMP_HIDDEN" type="id"></item>


### PR DESCRIPTION
First, IrcChannel setTopic messages were not previously parsed,
meaning that topic changes never showed up in Quasseldroid.  This
patch adds support for such messages.  Second, topic changes never
notified observers, causing the GUI to not be updated until the
selected buffer was changed.  This patch causes topic changes
(and, in the case of networks) network name changes, network server
changes, changes in the number of users, and changes in the lag
time to notify observers so the GUI is updated immediately.
