### PR TITLE
Fix crashing when a user joins a channel while init is incomplete

### DIFF
--- a/QuasselDroid/src/main/java/com/iskrembilen/quasseldroid/IrcUser.java
+++ b/QuasselDroid/src/main/java/com/iskrembilen/quasseldroid/IrcUser.java
@@ -49,6 +49,10 @@ public class IrcUser extends Observable implements Comparable<IrcUser> {
 
     @Override
     public int compareTo(IrcUser another) {
-        return this.nick.compareToIgnoreCase(another.nick);
+        if (this.nick != null) {
+            return this.nick.compareToIgnoreCase(another.nick);
+        } else {
+            return -1;
+        }
     }
 }


### PR DESCRIPTION
When a user joins a channel, the list of users with that user's
mode is sorted.  However, if init is incomplete, the new user's
nick may not have been set yet.  If the nick is not set, this
causes an NPE in the compareTo method.  This patch inserts a check
for the null nick and prevents the crash under those circumstances.
