### PR TITLE
Show buffer activity/unread/highlights even when parted.

### DIFF
--- a/QuasselDroid/src/main/java/com/iskrembilen/quasseldroid/Buffer.java
+++ b/QuasselDroid/src/main/java/com/iskrembilen/quasseldroid/Buffer.java
@@ -112,10 +112,6 @@ public class Buffer extends Observable implements Comparable<Buffer> {
         users = new UserCollection();
         this.dbHelper = dbHelper;
 
-        //Default active to true if channel is a query buffer, they are "always" active
-        //TODO: in quassel query are shown as offline if no shared channel, fix later
-        if (info.type == BufferInfo.Type.QueryBuffer) active = true;
-
         loadFilters();
     }
 

--- a/QuasselDroid/src/main/java/com/iskrembilen/quasseldroid/BufferUtils.java
+++ b/QuasselDroid/src/main/java/com/iskrembilen/quasseldroid/BufferUtils.java
@@ -38,7 +38,7 @@ public class BufferUtils {
 
     public static void setBufferViewStatus(Context context, Buffer entry, TextView bufferView) {
         //Check here if there are any unread messages in the buffer, and then set this color if there is
-        if (entry == null || !entry.isActive()) {
+        if (entry == null) {
             bufferView.setTextColor(ThemeUtil.bufferPartedColor);
         } else if (entry.hasUnseenHighlight()) {
             bufferView.setTextColor(ThemeUtil.bufferHighlightColor);
@@ -46,6 +46,8 @@ public class BufferUtils {
             bufferView.setTextColor(ThemeUtil.bufferUnreadColor);
         } else if (entry.hasUnreadActivity()) {
             bufferView.setTextColor(ThemeUtil.bufferActivityColor);
+        } else if (!entry.isActive()) {
+            bufferView.setTextColor(ThemeUtil.bufferPartedColor);
         } else {
             bufferView.setTextColor(ThemeUtil.bufferReadColor);
         }


### PR DESCRIPTION
Quasseldroid currently displays any parted buffer using the parted
buffer color, even if the buffer has activity, unread messages, or
highlights.  The problem is particularly bad for PM buffers with
nicks that share no channels with the user, causing no activity
to ever be shown for these buffers.  This patch makes Quasseldroid
use the same logic a regular Quassel, displaying activity, unread
messages, and highlights even if the buffer is parted.
Additionally, the patch removes the code in the Buffer constructor
that sets the buffer active if the buffer is a PM buffer, as this
action is now performed by BufferFragment.
