### PR TITLE
Input widget will no longer lose typed text when pressing "down" on D-pad

### DIFF
--- a/QuasselDroid/src/main/java/com/iskrembilen/quasseldroid/gui/fragments/ChatFragment.java
+++ b/QuasselDroid/src/main/java/com/iskrembilen/quasseldroid/gui/fragments/ChatFragment.java
@@ -171,7 +171,14 @@ public class ChatFragment extends SherlockFragment {
                 }
                 if (keyCode == KeyEvent.KEYCODE_DPAD_DOWN && event.getAction() == KeyEvent.ACTION_DOWN) {
                     EditText text = (EditText) v;
-                    text.setText(InputHistoryHelper.getPreviousHistoryEntry());
+                    if (InputHistoryHelper.isViewingHistory()) {
+                        // Currently viewing history, so progress back down towards "entry zero"
+                        text.setText(InputHistoryHelper.getPreviousHistoryEntry());
+                    } else if (!text.getText().toString().equals("")) {
+                        // Not viewing history, so push the current input text into the history and clear the input
+                        InputHistoryHelper.addHistoryEntry(text.getText().toString());
+                        text.setText("");
+                    }
                     text.setSelection(text.getText().length());
                     return true;
                 }

--- a/QuasselDroid/src/main/java/com/iskrembilen/quasseldroid/util/InputHistoryHelper.java
+++ b/QuasselDroid/src/main/java/com/iskrembilen/quasseldroid/util/InputHistoryHelper.java
@@ -43,4 +43,8 @@ public class InputHistoryHelper {
         if (currentIndex == -1)
             tempStore = text;
     }
+
+    public static boolean isViewingHistory() {
+        return (currentIndex >= 0);
+    }
 }


### PR DESCRIPTION
This fixes ShadowNinja's bug as reported on IRC:

![](http://i.imgur.com/uPxqcTe.png)
