### PR TITLE
Fix ArrayIndexOutOfBoundsException in IrcMessage::getHostmask() with senders with no "!"

### DIFF
--- a/QuasselDroid/src/main/java/com/iskrembilen/quasseldroid/IrcMessage.java
+++ b/QuasselDroid/src/main/java/com/iskrembilen/quasseldroid/IrcMessage.java
@@ -131,7 +131,11 @@ public class IrcMessage implements Comparable<IrcMessage> {
     }
 
     public String getHostmask() {
-        return getSender().split("!")[1];
+        try {
+            return getSender().split("!")[1];
+        } catch (ArrayIndexOutOfBoundsException ex) {
+            return "";
+        }
     }
 
     public void setFlag(Flag flag) {


### PR DESCRIPTION
I don't know why this happens, but my quasselcore appears to be sending occasional senders with a nick/host string without a "!" in. This would cause a crash when displaying buffers with affected senders.

This might be limited to my core or the MySQL support patch that we use, but a try-catch around a far-from-guaranteed function call can't hurt :) 
