### PR TITLE
Fix SSL cert validation against built-in root CAs

### DIFF
--- a/QuasselDroid/src/main/java/com/iskrembilen/quasseldroid/io/CustomTrustManager.java
+++ b/QuasselDroid/src/main/java/com/iskrembilen/quasseldroid/io/CustomTrustManager.java
@@ -34,9 +34,8 @@ class CustomTrustManager implements javax.net.ssl.X509TrustManager {
 
     CustomTrustManager(CoreConnection coreConnection) throws GeneralSecurityException {
         this.coreConnection = coreConnection;
-        KeyStore ks = KeyStore.getInstance(KeyStore.getDefaultType());
         TrustManagerFactory tmf = TrustManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
-        tmf.init(ks);
+        tmf.init((KeyStore)null);
 
         TrustManager tms[] = tmf.getTrustManagers();
 


### PR DESCRIPTION
Previously, the TrustManagerFactory was initialized with an empty
KeyStore, which caused it to reject all certificates.  Initializing
it with a null KeyStore instead will cause it to use the default
root CAs built in to Android, which will allow certificates issued
by those root CAs to be used without nagging the user.
