### PR TITLE
Changed minimum SDK version back to Gingerbread (7)

### DIFF
--- a/QuasselDroid/build.gradle
+++ b/QuasselDroid/build.gradle
@@ -26,7 +26,7 @@ android {
     compileSdkVersion 21
     buildToolsVersion '21.1.2'
     defaultConfig {
-        minSdkVersion 14
+        minSdkVersion 7
         targetSdkVersion 21
     }
 


### PR DESCRIPTION
This changed the minimum SDK version back to Gingerbread, which allows us to reach all of our previous users again.