### PR TITLE
Fixed a small layout bug in the chat view

### DIFF
--- a/QuasselDroid/src/main/res/layout/fragment_chat.xml
+++ b/QuasselDroid/src/main/res/layout/fragment_chat.xml
@@ -23,8 +23,6 @@
         <View
             android:layout_width="match_parent"
             android:layout_height="1dip"
-            android:layout_marginLeft="4dip"
-            android:layout_marginRight="4dip"
             android:background="?android:attr/dividerVertical" />
 
         <LinearLayout


### PR DESCRIPTION
In the holo guidelines dividers were supposed to have margin, this is NOT the case in Material anymore
