### PR TITLE
Changed "settings" to "preferences"

### DIFF
--- a/QuasselDroid/src/main/res/values/strings.xml
+++ b/QuasselDroid/src/main/res/values/strings.xml
@@ -19,7 +19,7 @@
     <!-- ACTIONS -->
 
     <string name="action_about">About</string>
-    <string name="action_preferences">Preferences</string>
+    <string name="action_preferences">Settings</string>
     <string name="action_manage_cores">Manage cores</string>
     <string name="action_join_channel">Join Channel</string>
     <string name="action_hide_events">Hide Events</string>


### PR DESCRIPTION
http://www.google.com/design/spec/patterns/settings.html#settings-settings
> The action for accessing Settings should always be simply labelled as “Settings”.