### PR TITLE
Fix stuck "Connecting" message

### DIFF
--- a/QuasselDroid/src/main/java/com/iskrembilen/quasseldroid/service/CoreConnService.java
+++ b/QuasselDroid/src/main/java/com/iskrembilen/quasseldroid/service/CoreConnService.java
@@ -346,6 +346,11 @@ public class CoreConnService extends Service {
         incomingHandler = null;
         if(Quasseldroid.status != Status.Disconnected) {
             BusProvider.getInstance().post(new ConnectionChangedEvent(Status.Disconnected));
+        }else{
+            // The only time this could conceivably happen is if Android tells us the network is
+            // disconnected while we are connecting.  In that case, let the user know the connection
+            // was not successful.
+            BusProvider.getInstance().post(new ConnectionChangedEvent(Status.Disconnected,"Connection failed!"));
         }
     }
 


### PR DESCRIPTION
If Android tells us the network is unavailable while we are
connecting, it would previously cause the Connecting message to get
stuck indefinitely with no error.  It would be a better idea to
display an error in this case so the user doesn't get confused.