### PR TITLE
Fix removing networks while Quasseldroid is running

### DIFF
--- a/QuasselDroid/src/main/java/com/iskrembilen/quasseldroid/NetworkCollection.java
+++ b/QuasselDroid/src/main/java/com/iskrembilen/quasseldroid/NetworkCollection.java
@@ -83,6 +83,7 @@ public class NetworkCollection extends Observable implements Observer {
     public void removeNetwork(int networkId) {
         Network network = networkMap.get(networkId);
         networkMap.remove(networkId);
+        networkList.remove(network);
         network.deleteObservers();
         Collections.sort(networkList);
         setChanged();


### PR DESCRIPTION
Previously, the network was removed from the map but not from the
list.  This caused networks to never disappear from the buffer list
after being deleted.