### PR TITLE
Fix another alphabetization problem with the nick list

### DIFF
--- a/QuasselDroid/src/main/java/com/iskrembilen/quasseldroid/UserCollection.java
+++ b/QuasselDroid/src/main/java/com/iskrembilen/quasseldroid/UserCollection.java
@@ -148,7 +148,7 @@ public class UserCollection extends Observable implements Observer {
             }
         }
         updateUniqueUsersSortedByMode();
-        notifyObservers(R.id.BUFFERUPDATE_USERSCHANGED);
+        update(null,null);
     }
 
     public void removeModeFromUser(IrcUser user, String mode) {
@@ -167,7 +167,7 @@ public class UserCollection extends Observable implements Observer {
             }
         }
         updateUniqueUsersSortedByMode();
-        notifyObservers(R.id.BUFFERUPDATE_USERSCHANGED);
+        update(null,null);
     }
 
     public ArrayList<IrcUser> getUniqueUsers() {


### PR DESCRIPTION
If users changed modes, the lists were not properly realphabetized
again.