### PR TITLE
Synchronize on same object

### DIFF
--- a/QuasselDroid/src/main/java/com/iskrembilen/quasseldroid/util/QuasseldroidNotificationManager.java
+++ b/QuasselDroid/src/main/java/com/iskrembilen/quasseldroid/util/QuasseldroidNotificationManager.java
@@ -179,7 +179,7 @@ public class QuasseldroidNotificationManager {
     }
 
     public void notifyHighlights() {
-        synchronized (highlightedMessages) {
+        synchronized (highlightedBuffers) {
 
             boolean displayColors = PreferenceManager.getDefaultSharedPreferences(context).getBoolean(context.getString(R.string.preference_colored_text), true);
 


### PR DESCRIPTION
Of the four synchronized() blocks in QuasseldroidNotificationManager, three were on highlightedBuffers, but the one in notifyHighlights was on highlightedMessages instead. This PR changes that one to highlightedBuffers as well.

This seems a likely cause of the following exception/crash I have seen when reconnecting sometimes:

    10-24 23:46:01.934 18211-18211/com.iskrembilen.quasseldroid.debug D/QuasseldroidNotificationManager: Notification/Intent: -1
    10-24 23:46:02.004 18211-19073/com.iskrembilen.quasseldroid.debug E/AndroidRuntime: FATAL EXCEPTION: Thread-198
    10-24 23:46:02.004 18211-19073/com.iskrembilen.quasseldroid.debug E/AndroidRuntime: Process: com.iskrembilen.quasseldroid.debug, PID: 18211
    10-24 23:46:02.004 18211-19073/com.iskrembilen.quasseldroid.debug E/AndroidRuntime: java.util.ConcurrentModificationException
    10-24 23:46:02.004 18211-19073/com.iskrembilen.quasseldroid.debug E/AndroidRuntime:     at java.util.ArrayList$ArrayListIterator.next(ArrayList.java:573)
    10-24 23:46:02.004 18211-19073/com.iskrembilen.quasseldroid.debug E/AndroidRuntime:     at com.iskrembilen.quasseldroid.util.QuasseldroidNotificationManager.notifyHighlights(QuasseldroidNotificationManager.java:282)
    10-24 23:46:02.004 18211-19073/com.iskrembilen.quasseldroid.debug E/AndroidRuntime:     at com.iskrembilen.quasseldroid.util.QuasseldroidNotificationManager.addMessage(QuasseldroidNotificationManager.java:166)
    10-24 23:46:02.004 18211-19073/com.iskrembilen.quasseldroid.debug E/AndroidRuntime:     at com.iskrembilen.quasseldroid.util.MessageUtil.checkMessageForHighlight(MessageUtil.java:57)
    10-24 23:46:02.004 18211-19073/com.iskrembilen.quasseldroid.debug E/AndroidRuntime:     at com.iskrembilen.quasseldroid.io.CoreConnection$ReadThread.doRun(CoreConnection.java:1362)
    10-24 23:46:02.004 18211-19073/com.iskrembilen.quasseldroid.debug E/AndroidRuntime:     at com.iskrembilen.quasseldroid.io.CoreConnection$ReadThread.run(CoreConnection.java:861)