### PR TITLE
Call disconnectFromCore() so the service actually stops.

### DIFF
--- a/QuasselDroid/src/main/java/com/iskrembilen/quasseldroid/service/CoreConnService.java
+++ b/QuasselDroid/src/main/java/com/iskrembilen/quasseldroid/service/CoreConnService.java
@@ -272,6 +272,7 @@ public class CoreConnService extends Service {
             connectToCore();
         } else {
             requestedDisconnect = true;
+            disconnectFromCore();
         }
     }
 


### PR DESCRIPTION
Without this call the CoreConnService keeps running in the
background when the disconnect Intent from the notification is received