### PR TITLE
Fix race condition with LAST_SEEN while receiving messages

### DIFF
--- a/QuasselDroid/src/main/java/com/iskrembilen/quasseldroid/util/MessageUtil.java
+++ b/QuasselDroid/src/main/java/com/iskrembilen/quasseldroid/util/MessageUtil.java
@@ -156,8 +156,8 @@ public class MessageUtil {
             if (buffer == null || buffer.isDisplayed())
                 return;
 
-            // If the message wasn’t read yet, we want to add a notification
-            if (buffer.getLastSeenMessage() < message.messageId && !buffer.isPermanentlyHidden() && !message.isFiltered())
+            // notificationManager will check if the message was already read
+            if (!buffer.isPermanentlyHidden() && !message.isFiltered())
                 notificationManager.addMessage(message);
         }
     }

--- a/QuasselDroid/src/main/java/com/iskrembilen/quasseldroid/util/QuasseldroidNotificationManager.java
+++ b/QuasselDroid/src/main/java/com/iskrembilen/quasseldroid/util/QuasseldroidNotificationManager.java
@@ -214,6 +214,11 @@ public class QuasseldroidNotificationManager {
 
     public void addMessage(IrcMessage message) {
         synchronized (highlightedBuffers) {
+
+            Buffer buffer = Client.getInstance().getNetworks().getBufferById(message.bufferInfo.id);
+            if (buffer.getLastSeenMessage() >= message.messageId)
+                return;
+
             // If the buffer in question isn’t in the list of highlighted buffers, add it
             if (!highlightedBuffers.contains(message.bufferInfo.id)) {
                 highlightedBuffers.add(message.bufferInfo.id);


### PR DESCRIPTION
This PR should fix a race condition when receiving LAST_SEEN updates while also receiving new messages. If `processMessage()` checks `buffer.getLastSeenMessage()` before
`notifyHighlightsRead()` is called, but `notificationManager.addMessage()` is processed afterwards, the new message will trigger a highlight.

Moving the `getLastSeenMessage()` check inside the
`synchronized (highlightedBuffers)` removes this race condition, since
`SET_LAST_SEEN_TO_SERVICE` processing in `CoreConnService` sets last seen
before calling `notifyHighlightsRead()`.

This issue was causing random old messages to produce notifications when opening QuasselDroid.