### PR TITLE
Fix Android Oreo font color

### DIFF
--- a/QuasselDroid/src/main/java/com/iskrembilen/quasseldroid/util/SpanUtils.java
+++ b/QuasselDroid/src/main/java/com/iskrembilen/quasseldroid/util/SpanUtils.java
@@ -28,6 +28,6 @@ import android.text.style.CharacterStyle;
 
 public class SpanUtils {
     public static void setFullSpan(Spannable text, CharacterStyle style) {
-        text.setSpan(style, 0, text.length(), Spannable.SPAN_INCLUSIVE_INCLUSIVE);
+        text.setSpan(style, 0, text.length(), Spannable.SPAN_INCLUSIVE_EXCLUSIVE);
     }
 }


### PR DESCRIPTION
Using `Spannable#SPAN_INCLUSIVE_INCLUSIVE` in `SpanUtils#setFullSpan` will cause text in the chat fragment to have the same color as the user's nick after upgrading to Android Oreo.

Changing this to `Spannable#SPAN_INCLUSIVE_EXCLUSIVE` resolves the issue.